### PR TITLE
google-auth-oauthlib 1.2.1

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,7 +1,5 @@
 {% set name = "google-auth-oauthlib" %}
-{% set version = "0.5.2" %}
-{% set sha256 = "d5e98a71203330699f92a26bc08847a92e8c3b1b8d82a021f1af34164db143ae" %}
-{% set build = "0" %}
+{% set version = "1.2.1" %}
 
 package:
   name: {{ name|lower }}
@@ -9,13 +7,13 @@ package:
 
 source:
   fn: {{ name }}-{{ version }}.tar.gz
-  url: https://pypi.io/packages/source/{{ name[0] }}/{{ name }}/{{ name }}-{{ version }}.tar.gz
-  sha256: {{ sha256 }}
+  url: https://pypi.io/packages/source/{{ name[0] }}/{{ name }}/{{ name.replace('-', '_') }}-{{ version }}.tar.gz
+  sha256: afd0cad092a2eaa53cd8e8298557d6de1034c6cb4a740500b5357b648af97263
 
 build:
-  number: {{ build }}
+  number: 0
   skip: True  # [py<36]
-  script: {{ PYTHON }} -m pip install . --no-deps -vv
+  script: {{ PYTHON }} -m pip install . --no-deps -vv --no-build-isolation
   entry_points:
     - google-oauthlib-tool = google_auth_oauthlib.tool.__main__:main
 
@@ -28,7 +26,7 @@ requirements:
 
   run:
     - python
-    - google-auth >=1.0.0
+    - google-auth >=2.15.0
     - requests-oauthlib >=0.7.0
     - click >=6.0.0
 
@@ -48,7 +46,7 @@ about:
   license_file: LICENSE
   summary: Google Authentication Library, oauthlib integration with google-auth
   description: This library provides oauthlib integration with google-auth.
-  doc_url: http://google-auth-oauthlib.readthedocs.io/en/latest/
+  doc_url: https://google-auth-oauthlib.readthedocs.io
   dev_url: https://github.com/googleapis/google-auth-library-python-oauthlib
 
 extra:


### PR DESCRIPTION
**Destination channel:** defaults

### Links

- [PKG-5703](https://anaconda.atlassian.net/browse/PKG-5703)
- [Upstream repository](https://github.com/googleapis/google-auth-library-python-oauthlib/tree/v1.2.1)
- [Upstream changelog/diff](https://github.com/googleapis/google-auth-library-python-oauthlib/blob/v1.2.1/CHANGELOG.md)

### Explanation of changes:

- Update version
- Remove redundant jinja2 templating
- Update dependencies
- Linter fixes


[PKG-5703]: https://anaconda.atlassian.net/browse/PKG-5703?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ